### PR TITLE
Add evaluation sheet creation and history log

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -143,10 +143,11 @@ function processEvaluation(data) {
       }
     }
 
-    // Write the AI-powered results
-    writeAIResult(aiEvaluation);
+    // Write the AI-powered results and history
+    const sheetName = writeAIResult(aiEvaluation);
+    appendEvaluationHistory(aiEvaluation);
 
-    return { success: true };
+    return { success: true, sheetName: sheetName };
 
   } catch (error) {
     // If AI fails, fall back to simple evaluation
@@ -352,13 +353,19 @@ function addResultHeaders(sheet) {
 
 // COMPLETELY REVISED writeAIResult function
 function writeAIResult(result) {
-  const sheet = SpreadsheetApp.getActiveSpreadsheet().getSheetByName('Results');
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
 
-  // Determine the next available row without clearing previous results
+  // Build a unique sheet name based on device and timestamp
+  const baseName = result.deviceName.substring(0, 40);
+  const ts = Utilities.formatDate(new Date(), ss.getSpreadsheetTimeZone(), 'yyyyMMdd_HHmmss');
+  let sheetName = baseName + ' ' + ts;
+  sheetName = sheetName.replace(/[\[\]\?:*\/\\]/g, '');
 
-  // Write evaluation header
-  const lastRow = sheet.getLastRow();
-  const newRow = lastRow + 1;
+  const sheet = ss.insertSheet(sheetName);
+  ss.setActiveSheet(sheet);
+
+  // Start writing the report at the top of the new sheet
+  const newRow = 1;
 
   // Title
   sheet.getRange(newRow, 1).setValue('🔋 Wi-Charge Evaluation Report');
@@ -492,6 +499,39 @@ function writeAIResult(result) {
   // Set column widths for better readability
   sheet.setColumnWidth(1, 150);
   sheet.setColumnWidth(5, 300);
+
+  return sheetName;
+}
+
+// Append a summary entry to the evaluations_history sheet
+function appendEvaluationHistory(result) {
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  let sheet = ss.getSheetByName('evaluations_history');
+  if (!sheet) {
+    sheet = ss.insertSheet('evaluations_history');
+    const headers = ['Date', 'Device', 'Total Score', 'Verdict', 'Pain Intensity',
+      'Coverage Geometry', 'Install Leverage', 'Regulatory & Shipping', 'ROI Math',
+      'Fleet Size', 'Strategic Halo', 'Competitive Threat'];
+    sheet.appendRow(headers);
+    sheet.getRange(1, 1, 1, headers.length).setFontWeight('bold');
+  }
+
+  const row = [
+    new Date(),
+    result.deviceName,
+    result.totalScore,
+    result.verdict,
+    result.scores.painIntensity.score,
+    result.scores.coverageGeometry.score,
+    result.scores.installLeverage.score,
+    result.scores.regulatoryShipping.score,
+    result.scores.roiMath.score,
+    result.scores.fleetSize.score,
+    result.scores.strategicHalo.score,
+    result.scores.competitiveThreat.score
+  ];
+
+  sheet.appendRow(row);
 }
 
 /**

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ This Google Sheets add‑on evaluates device ideas for use with Wi‑Charge wire
 2. Select **Start New Evaluation** and fill in device information. Only the device name is required.
 3. Choose **View Technical Reference** to see transmitter specs or **About AI Mode** for details about the evaluation process.
 4. Run **Test AI Connection** to verify the API key works.
-5. After running an evaluation, results are written to the **Results** sheet.
+5. After running an evaluation, a new sheet containing the full report is created
+   and a summary row is added to the **evaluations_history** sheet.
 
 
 ## Settings

--- a/Sidebar.html
+++ b/Sidebar.html
@@ -155,7 +155,13 @@ if (!data.name) {
         document.getElementById('swapCost').value = '';
         document.getElementById('description').value = '';
 
-        alert('✅ Evaluation complete! Check the Results sheet.');
+        var msg = '✅ Evaluation complete!';
+        if (result && result.sheetName) {
+          msg += ' Sheet "' + result.sheetName + '" was created.';
+        } else {
+          msg += ' Check the spreadsheet for details.';
+        }
+        alert(msg);
       }
 
       function onFailure(error) {


### PR DESCRIPTION
## Summary
- create a new sheet for each AI evaluation
- log a summary row in `evaluations_history`
- show the created sheet name on success in the sidebar
- document the new behaviour in the README

## Testing
- `git status --short`